### PR TITLE
VSCode and Python 3.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,5 @@ dmypy.json
 cython_debug/
 
 /.idea
+/.vscode
 *.DS_Store

--- a/schemey/factory/dataclass_schema_factory.py
+++ b/schemey/factory/dataclass_schema_factory.py
@@ -101,6 +101,7 @@ class DataclassSchemaFactory(SchemaFactoryABC):
                 p = params_with_default
             else:
                 p = params
+            # pylint: disable=E3701
             field = dataclasses.field(
                 default=default, metadata={"schemey": field_schema}
             )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
             "pytest~=7.2",
             "pytest-cov~=4.0",
             "pytest-xdist~=3.2",
-            "pylint~=2.17",
+            "pylint~=3.0",
         ],
     },
     setup_requires=["setuptools-git-versioning"],


### PR DESCRIPTION
Added a gitignore directive for .vscode and bumped the version of pylint to support python 3.12